### PR TITLE
Update for Spree 2.4. Add complete I18n

### DIFF
--- a/app/assets/javascripts/spree/backend/pickup_list_builder.js
+++ b/app/assets/javascripts/spree/backend/pickup_list_builder.js
@@ -38,7 +38,7 @@ PickupListBuilder.prototype.buildPickupTemplate = function(index, pickupObject) 
       $pickupRadioDiv = $('<div/>', { class: 'funkyradio' }),
       $dispatchDiv = $('<div/>', { class: "pull-right dispatch funkyradio-warning" }),
       $radioInput = $('<input/>', {type: 'radio', name: "pickup_location", id: ('pickup_location_' + pickupObject.id) } ),
-      $radioLabel = $('<label/>', { for: ('pickup_location_' + pickupObject.id), text: 'Dispatch' });
+      $radioLabel = $('<label/>', { for: ('pickup_location_' + pickupObject.id), text: Spree.translations.dispatch });
 
   $localAddressDiv.append($localitySpan, $regionSpan, $zipcodeSpan, $countrySpan);
   $adrDiv.append($streetAddressDiv, $localAddressDiv);
@@ -57,12 +57,16 @@ PickupListBuilder.prototype.imageUrlBuilder = function(value) {
 
 PickupListBuilder.prototype.timeDecorator = function(object) {
   var startTime = new Date(object.start_time);
-  var endTime = new Date(object.end_time)
-  return(startTime.getHours() + ':' + startTime.getMinutes() + " - " + endTime.getHours() + ':' + endTime.getMinutes() )
+  var endTime   = new Date(object.end_time)
+  var startHours   = ('0' + startTime.getHours()).slice(-2)
+  var startMinutes = ('0' + startTime.getMinutes()).slice(-2)
+  var endHours     = ('0' + endTime.getHours()).slice(-2)
+  var endMinutes   = ('0' + endTime.getMinutes()).slice(-2)
+  return(startHours + ':' + startMinutes + " - " + endHours + ':' + endMinutes )
 };
 
 PickupListBuilder.prototype.daysDecorator = function(object) {
-  var days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'];
+  var days = Spree.translations.abbr_day_names;
   return object.timings.map(function(data) {
     return(days[data.day_id]);
   }).join(', ');

--- a/app/assets/javascripts/spree/backend/pickup_locations_getter.js
+++ b/app/assets/javascripts/spree/backend/pickup_locations_getter.js
@@ -1,7 +1,7 @@
 function PickupLocationGetter(path) {
   this.path = path
-  this.stateSelect = $('#state .select22');
-  this.countrySelect = $('#country-select .select22');
+  this.stateSelect = $('#state .select2');
+  this.countrySelect = $('#country-select .select2');
 }
 
 PickupLocationGetter.prototype.init = function() {
@@ -12,8 +12,8 @@ PickupLocationGetter.prototype.bindEvent = function() {
   var _this = this;
   this.bindFetchStates();
   this.stateSelect.on('change', function(event) {
-    var s_id = _this.stateSelect.val();
-    var c_id = _this.countrySelect.val();
+    var s_id = _this.stateSelect.find(':selected').val();
+    var c_id = _this.countrySelect.find(':selected').val();
     path = _this.buildPath(s_id, c_id);
     $.get(path, function(data, status) {
       _this.initializeModalBuilder(data);

--- a/app/assets/javascripts/spree/backend/pickup_translations.js.erb
+++ b/app/assets/javascripts/spree/backend/pickup_translations.js.erb
@@ -1,0 +1,3 @@
+_.extend(Spree.translations, {
+  dispatch: "<%= Spree.t(:dispatch) %>"
+});

--- a/app/assets/javascripts/spree/backend/spree_pickup.js
+++ b/app/assets/javascripts/spree/backend/spree_pickup.js
@@ -1,5 +1,6 @@
 // Placeholder manifest file.
 // the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'
+//= require 'spree/backend/pickup_translations.js'
 //= require 'spree/backend/shipment_decorator.js'
 //= require 'spree/shared/map_initializer.js'
 //= require 'spree/shared/pickup_checkout.js'

--- a/app/assets/javascripts/spree/frontend/pickup_locations_getter.js
+++ b/app/assets/javascripts/spree/frontend/pickup_locations_getter.js
@@ -1,7 +1,7 @@
 function PickupLocationGetter(path) {
   this.path = path
-  this.stateSelect = $('#state .select22');
-  this.countrySelect = $('#country-select .select22');
+  this.stateSelect = $('#state .select2');
+  this.countrySelect = $('#country-select .select2');
 }
 
 PickupLocationGetter.prototype.init = function() {

--- a/app/assets/javascripts/spree/shared/map_initializer.js
+++ b/app/assets/javascripts/spree/shared/map_initializer.js
@@ -17,9 +17,9 @@ MapInitializer.prototype.init = function() {
 
 MapInitializer.prototype.initializeMap = function() {
   this.map = new google.maps.Map(document.getElementById('map'), {
-              center: {lat: 44.540, lng: -78.546},
-              zoom: 11
-             });
+    center: {lat: 44.540, lng: -78.546},
+    zoom: 11
+  });
 };
 
 MapInitializer.prototype.bindEvent = function() {

--- a/app/controllers/spree/admin/pickup_locations_controller.rb
+++ b/app/controllers/spree/admin/pickup_locations_controller.rb
@@ -5,6 +5,8 @@ module Spree
 
       before_action :set_country, only: :new
 
+      helper Spree::PickupHelper
+
       def create
         invoke_callbacks(:create, :before)
         @object.attributes = permitted_resource_params

--- a/app/controllers/spree/api/v1/pickup_locations_controller.rb
+++ b/app/controllers/spree/api/v1/pickup_locations_controller.rb
@@ -3,13 +3,19 @@ module Spree
     module V1
       class PickupLocationsController < Spree::Api::BaseController
 
-        skip_before_action :check_for_user_or_api_key
+        # skip_before_action :check_for_user_or_api_key
         skip_before_action :authenticate_user
 
         def search
-          @pickup_locations = Spree::PickupLocation.includes(address: [:state, :country])
-                                                   .where(spree_addresses: {state_id: params[:s_id], country_id: params[:c_id]})
-          render json: @pickup_locations.to_json(include: [:timings, {address: {include: [:state, :country]}}] )
+          @pickup_locations = Spree::PickupLocation.
+            includes(address: [:state, :country]).
+            where(spree_addresses: {
+              state_id: params[:s_id],
+              country_id: params[:c_id]
+            })
+          render json: @pickup_locations.to_json(
+            include: [:timings, {address: {include: [:state, :country]}}]
+          )
         end
 
       end

--- a/app/helpers/spree/pickup_helper.rb
+++ b/app/helpers/spree/pickup_helper.rb
@@ -1,0 +1,5 @@
+module Spree::PickupHelper
+  def i18n_day_names
+    I18n.t('date.day_names').map(&:capitalize)
+  end
+end

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -4,7 +4,7 @@ Spree::Stock::Estimator.class_eval do
     package.shipping_methods.select do |ship_method|
       calculator = ship_method.calculator
       begin
-        valid = ship_method.available_to_display(display_filter) &&
+        valid = ship_method.available_to_display?(display_filter) &&
         ship_method.include?(order.ship_address) &&
         calculator.available?(package) &&
         (calculator.preferences[:currency].blank? ||

--- a/app/overrides/add_condition_in_order_detail.rb
+++ b/app/overrides/add_condition_in_order_detail.rb
@@ -2,7 +2,7 @@ Deface::Override.new(
   virtual_path: 'spree/shared/_order_details',
   name: 'add_condition_in_order_details',
   replace: '[data-hook="order-ship-address"]',
-  text: ' <% title = order.pickup? ? "Pick up Address" : Spree.t(:shipping_address) %>
+  text: ' <% title = order.pickup? ? Spree.t(:pickup_address) : Spree.t(:shipping_address) %>
           <div class="col-md-3" data-hook="order-ship-address">
             <h4><%= title %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless order.completed? %></h4>
             <%= render "spree/shared/address", address: order.ship_address %>

--- a/app/overrides/add_pick_up_location_in_configuration.rb
+++ b/app/overrides/add_pick_up_location_in_configuration.rb
@@ -2,5 +2,7 @@ Deface::Override.new(
   virtual_path: 'spree/admin/shared/sub_menu/_configuration',
   name: 'add_pick_up_location_in_configuration',
   insert_bottom: '[data-hook="admin_configurations_sidebar_menu"]',
-  text: '<%= configurations_sidebar_menu_item Spree.t(:pickup_locations), spree.admin_pickup_locations_path %>'
+  text: '<%= configurations_sidebar_menu_item Spree.t(:pickup_locations), '\
+        'spree.admin_pickup_locations_path %>',
+  original: '28204a1f46d26e6579991e4e85b67317e50458d5'
 )

--- a/app/overrides/add_pickable_in_shipping_method.rb
+++ b/app/overrides/add_pickable_in_shipping_method.rb
@@ -6,12 +6,12 @@ Deface::Override.new(
           <div class="panel panel-default">
             <div class="panel-heading">
               <h1 class="panel-title">
-                Pickupable
+                <%= Spree.t(:pickup) %>
               </h1>
             </div>
 
             <div class="panel-body">
-              <%= f.check_box :pickupable %>
+              <%= f.check_box :pickupable  %>
               <%= f.label :pickupable %>
             </div>
           </div>

--- a/app/overrides/add_ship_condition.rb
+++ b/app/overrides/add_ship_condition.rb
@@ -16,16 +16,16 @@ Deface::Override.new(
       <% end %>
 
       <% if((shipment.shipped? || shipment.ready_for_pickup?) && shipment.inventory_units.where.not(state: "returned").any? and can?(:update, shipment)) %>
-        <%= link_to "Deliver", "javascript:;", class: "deliver pull-right btn btn-sm btn-success", data: { "shipment-number"=> shipment.number } %>
+        <%= link_to Spree.t(:deliver), "javascript:;", class: "deliver pull-right btn btn-sm btn-success", data: { "shipment-number"=> shipment.number } %>
         <div class="clearfix"></div>
       <% end %>
 
       <% if(@order.pickup? && (shipment.shipped_for_pickup? || shipment.ready?) && can?(:update, shipment)) %>
-        <%= link_to "Pick up Ready", "javascript:;", class: "pickup_ready pull-right btn-sm btn btn-success lm-5", data: { "shipment-number"=> shipment.number } %>
+        <%= link_to Spree.t(:pickup_ready), "javascript:;", class: "pickup_ready pull-right btn-sm btn btn-success lm-5", data: { "shipment-number"=> shipment.number } %>
       <% end %>
 
       <% if(@order.pickup? && shipment.ready? && can?(:update, shipment)) %>
-        <%= link_to "Shipped to Pickup Location", "javascript:;", class: "pickup_ship btn-sm pull-right btn btn-success", data: { "shipment-number"=> shipment.number } %>
+        <%= link_to Spree.t(:shipped_to_pickup_location), "javascript:;", class: "pickup_ship btn-sm pull-right btn btn-success", data: { "shipment-number"=> shipment.number } %>
       <% end %>
       <br/><br/>
 

--- a/app/views/spree/admin/orders/customer_details/_pickup_location_form.html.erb
+++ b/app/views/spree/admin/orders/customer_details/_pickup_location_form.html.erb
@@ -7,17 +7,17 @@
     <div class="form-group col-md-4" data-hook="pickup_location_country">
       <%= label_tag :country_id, Spree.t(:country) %>
       <span id="country-select">
-        <%= collection_select :pickup_location, :country_id, available_countries, :id, :name, {selected: selected_country_id}, { class: "select22 select-width" } %>
+        <%= collection_select :pickup_location, :country_id, available_countries, :id, :name, {selected: selected_country_id}, { class: "select2" } %>
       </span>
     </div>
     <div class="form-group col-md-4" data-hook="pickup_location_state">
       <%= label_tag :state_id, Spree.t(:state) %>
       <span id="state" class="region">
-        <%= collection_select :pickup_location, :state_id, selected_country_states, :id, :name, { selected: selected_state_id, include_blank: true }, { class: "select22 select-width", style: ""} %>
+        <%= collection_select :pickup_location, :state_id, selected_country_states, :id, :name, { selected: selected_state_id, include_blank: true }, { class: "select2", style: ""} %>
       </span>
     </div>
     <div class='col-md-2'>
-      <a href="javascript:void(0)" class=' btn btn-warning toggle-map btn-xs hide'>Show/Hide Map</a>
+      <a href="javascript:void(0)" class=' btn btn-warning toggle-map btn-xs hide'><%= Spree.t(:show_hide_map) %></a>
     </div>
     <%=f.hidden_field :pickup_location_id, class: 'pickup_id'%>
   </div>
@@ -34,12 +34,13 @@
   <%=javascript_include_tag "spree/backend/pickup_locations_getter"%>
   <%=javascript_include_tag "spree/shared/map_initializer"%>
   <%=javascript_include_tag "spree/backend/pickup_list_builder"%>
+  <%=javascript_include_tag "spree/backend/pickup_translations"%>
   <script src="https://maps.googleapis.com/maps/api/js?key=<%=Rails.application.secrets.google_map_key%>"
     ></script>
   <%= javascript_tag do %>
     $(function(){
       var pickupCheckout = new PickupCheckout($('#pickup_address'), $('#shipping_address'));
-      var pickupLocationGetter = new PickupLocationGetter('<%= api_pickup_locations_search_path %>');
+      var pickupLocationGetter = new PickupLocationGetter('<%= api_v1_pickup_locations_search_path %>');
       pickupLocationGetter.init();
       <% if pickup_location_present %>
         $('#state').find('select').trigger('change');

--- a/app/views/spree/admin/pickup_locations/_form.html.erb
+++ b/app/views/spree/admin/pickup_locations/_form.html.erb
@@ -11,12 +11,12 @@
   <%=f.fields_for :address do |f|%>
 
   <div class="form-group" data-hook="pickup_location_first_name">
-    <%= f.label :first_name, 'First Name' %>
+    <%= f.label :first_name, Spree.t(:first_name) %>
     <%= f.text_field :first_name, class: 'form-control' %>
   </div>
 
   <div class="form-group" data-hook="pickup_location_last_name">
-    <%= f.label :last_name, 'Last Name' %>
+    <%= f.label :last_name, Spree.t(:last_name) %>
     <%= f.text_field :last_name, class: 'form-control' %>
   </div>
 
@@ -61,9 +61,9 @@
 
 
   <%= f.field_container :open_day_ids, class: ['form-group'] do %>
-    <%= f.label :open_day_ids, 'Open Days' %>
+    <%= f.label :open_day_ids, Spree.t(:open_days) %>
     <%#f.object.open_day_ids = Date::DAYNAMES.zip((0..6).to_a)%>
-    <%= f.select :open_day_ids, Date::DAYNAMES.zip((0..6).to_a), { selected: (0..6).to_a}, { multiple: true, class: "select2" } %>
+    <%= f.select :open_day_ids, i18n_day_names.zip((0..6).to_a), { selected: (0..6).to_a}, { multiple: true, class: "select2" } %>
   <% end %>
 
   <div class="form-group col-md-6">
@@ -74,7 +74,7 @@
     <%= f.label :end_time %>
     <%= f.time_field :end_time %>
   </div>
-  
+
 </div>
 
 <% content_for :head do %>

--- a/app/views/spree/checkout/_pickup_location_form.html.erb
+++ b/app/views/spree/checkout/_pickup_location_form.html.erb
@@ -7,13 +7,13 @@
     <div class="form-group col-md-4" data-hook="pickup_location_country">
       <%= label_tag :country_id, Spree.t(:country) %>
       <span id="country-select">
-        <%= collection_select :pickup_location, :country_id, available_countries, :id, :name, {selected: selected_country_id}, { class: "select22 select-width" } %>
+        <%= collection_select :pickup_location, :country_id, available_countries, :id, :name, {selected: selected_country_id}, { class: "select2 select-width" } %>
       </span>
     </div>
     <div class="form-group col-md-4" data-hook="pickup_location_state">
       <%= label_tag :state_id, Spree.t(:state) %>
       <span id="state" class="region">
-        <%= collection_select :pickup_location, :state_id, selected_country_states, :id, :name, { selected: selected_state_id, include_blank: true }, { class: "select22 select-width", style: ""} %>
+        <%= collection_select :pickup_location, :state_id, selected_country_states, :id, :name, { selected: selected_state_id, include_blank: true }, { class: "select2 select-width", style: ""} %>
       </span>
     </div>
     <div class='col-md-2'>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,4 +3,5 @@ Rails.application.config.assets.precompile += %w( spree/shared/map_initializer.j
 Rails.application.config.assets.precompile += %w( spree/shared/spree_states_fetcher.js)
 Rails.application.config.assets.precompile += %w( spree/backend/pickup_list_builder.js)
 Rails.application.config.assets.precompile += %w( spree/backend/pickup_locations_getter.js)
+Rails.application.config.assets.precompile += %w( spree/backend/pickup_translations.js)
 Rails.application.config.assets.precompile += %w( spree/frontend/pickup_locations_getter.js)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,12 +1,39 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    models:
+      spree/pickup_location:
+        one: Pickup location
+        few: Pickup locations
+        many: Pickup locations
+        other: Pickup locations
+    attributes:
+      spree/pickup_location:
+        name: Name
+        address_id: Address
+        phone: Phone
+        longitute: Longitute
+        latitude: Latitude
+        start_time: Start time
+        end_time: End time
+      spree/shipping_method:
+        pickupable: Pickupable
   spree:
+    back_to_pickup_locations_list: Back to Pickup Locations list
+    deliver: Deliver
+    dispatch: Dispatch
     ensure_pickup_or_ship_address_present: Either Ship Address or Pickup Address must be present
     greater_than_start_time: must be greater than start time
+    new_pickup_location: New pickup location
+    open_days: Open days
+    pickup: Pickup
+    pickup_address: Pickup address
+    pickup_location: Pickup location
+    pickup_locations: Pickup locations
+    pickup_ready: Pick up Ready
     shipment_states:
       delivered: delivered
       ready_for_pickup: ready for pickup
       shipped_for_pickup: shipped for pickup
+    shipped_to_pickup_location: Shipped to Pickup Location
+    show_hide_map: Show/Hide Map
+

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,38 @@
+ru:
+  activerecord:
+    models:
+      spree/pickup_location:
+        one: Пункт самовывоза
+        few: Пункта самовывоза
+        many: Пунктов самовывоза
+        other: Пункты самовывоза
+    attributes:
+      spree/pickup_location:
+        name: Название
+        address_id: Адрес
+        phone: Телефон
+        longitute: Долгота
+        latitude: Широта
+        start_time: Начало работы
+        end_time: Конец работы
+      spree/shipping_method:
+        pickupable: Самовывоз доступен
+  spree:
+    back_to_pickup_locations_list: Назад к пунктам самовывоза
+    deliver: Доставить
+    dispatch: Отгрузить
+    ensure_pickup_or_ship_address_present: Должен присутствовать адрес доставки или пункт самовывоза
+    greater_than_start_time: должна быть позже даты начала
+    new_pickup_location: Новый пункт самовывоза
+    open_days: Рабочие дни
+    pickup: Самовывоз
+    pickup_address: Адрес самовывоза
+    pickup_location: Пункт самовывоза
+    pickup_locations: Пункты самовывоза
+    pickup_ready: В пункте самовывоза
+    shipment_states:
+      delivered: Доставлен
+      ready_for_pickup: Готов для забора
+      shipped_for_pickup: Отправлен в пункт самовывоза
+    shipped_to_pickup_location: Отправлен в пункт самовывоза
+    show_hide_map: Показать/Скрыть карту

--- a/db/migrate/20160531065135_create_spree_pickup_locations.rb
+++ b/db/migrate/20160531065135_create_spree_pickup_locations.rb
@@ -1,4 +1,4 @@
-class CreateSpreePickupLocations < ActiveRecord::Migration
+class CreateSpreePickupLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_pickup_locations do |t|
       t.string   :name

--- a/db/migrate/20160606065945_add_pickable_in_shipping_methods.rb
+++ b/db/migrate/20160606065945_add_pickable_in_shipping_methods.rb
@@ -1,4 +1,4 @@
-class AddPickableInShippingMethods < ActiveRecord::Migration
+class AddPickableInShippingMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipping_methods, :pickupable, :boolean, default: false
   end

--- a/db/migrate/20160606123414_add_pickup_location_id_in_order.rb
+++ b/db/migrate/20160606123414_add_pickup_location_id_in_order.rb
@@ -1,4 +1,4 @@
-class AddPickupLocationIdInOrder < ActiveRecord::Migration
+class AddPickupLocationIdInOrder < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :pickup_location_id, :integer
     add_index :spree_orders, :pickup_location_id

--- a/db/migrate/20160613063332_create_spree_timings.rb
+++ b/db/migrate/20160613063332_create_spree_timings.rb
@@ -1,4 +1,4 @@
-class CreateSpreeTimings < ActiveRecord::Migration
+class CreateSpreeTimings < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_timings do |t|
       t.integer :day_id

--- a/spree_pickup.gemspec
+++ b/spree_pickup.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_pickup'
-  s.version     = '3.1.0'
+  s.version     = '3.4.0'
   s.summary     = 'User can select pickup location for any of the order'
   s.description = 'User can select pickup location for any of the order'
   s.required_ruby_version = '>= 2.1.0'
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_api',         '~> 3.1.0'
-  s.add_dependency 'spree_backend',     '~> 3.1.0'
-  s.add_dependency 'spree_core',        '~> 3.1.0'
-  s.add_dependency 'spree_frontend',    '~> 3.1.0'
+  s.add_dependency 'spree_api',         '~> 3.4.0'
+  s.add_dependency 'spree_backend',     '~> 3.4.0'
+  s.add_dependency 'spree_core',        '~> 3.4.0'
+  s.add_dependency 'spree_frontend',    '~> 3.4.0'
 
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
I updated the dependencies in the gemset to match spree '~> 2.4.0' and fixed all bugs, so this extension is working with spree 2.4.1.

I also completely I18n'ized the extension, translating all text for both English and Russian.